### PR TITLE
Scope dispensaries collection to current admin user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.3.1'
+
 #STEVE ADDITIONS:
 gem 'will_paginate', '3.0.7' # PAGINATION
 gem 'bootstrap-will_paginate', '0.0.10' # BOOTSTRAP STYLING
@@ -62,7 +64,7 @@ gem 'active_admin_role'
 gem 'active_skin'
 gem "active_admin_import"
 gem 'best_in_place', github: 'bernat/best_in_place'
-gem 'cancancan'
+gem 'cancancan', '2.1.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/activeadmin/activeadmin.git
-  revision: 2cf85fb03ab382a85b84cc3185c7be542969009c
+  revision: dabd8b30874fe177dcc14e5ebda3fd7b892f3c72
   specs:
     activeadmin (2.0.0.alpha)
       arbre (>= 1.1.1)
@@ -571,7 +571,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.6)
   bootstrap-will_paginate (= 0.0.10)
   byebug
-  cancancan
+  cancancan (= 2.1.3)
   canonical-rails (~> 0.2.1)
   capybara (= 2.7.1)
   carrierwave (~> 0.11.2)
@@ -624,5 +624,8 @@ DEPENDENCIES
   web-console (~> 2.0)
   will_paginate (= 3.0.7)
 
+RUBY VERSION
+   ruby 2.3.1p112
+
 BUNDLED WITH
-   1.11.2
+   1.16.1

--- a/app/dispensary_admin/dispensaries.rb
+++ b/app/dispensary_admin/dispensaries.rb
@@ -29,6 +29,12 @@ ActiveAdmin.register Dispensary, namespace: :dispensary_admin , as: "Dispensary"
 	#no filters
 	before_filter :skip_sidebar!, :only => :index
 
+	controller do
+		def scoped_collection
+			end_of_association_chain.where(admin_user_id: current_admin_user.id)
+		end
+	end
+
 	#scopes
 	scope_to :current_user
 	#scope :mine, default: true

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,13 +1,12 @@
 class Ability
   include CanCan::Ability
-  include ActiveAdminRole::CanCan::Ability
 
   def initialize(user)
-  
-    can :read, :all # permissions for every user, even if not logged in 
-    
+
+    can :read, :all # permissions for every user, even if not logged in
+
     if user.present?
-      if user.role = 99
+      if user.is_admin?
         can :manage, :all
       else
         can :read, ActiveAdmin::Page, name: "Dashboard", namespace_name: "dispensary_admin"
@@ -15,17 +14,11 @@ class Ability
         #can :manage, DspPrice
         can :read, Product
         can :manage, AdminUser, id: user.id
-      
+
         #need to set the adminuser id on dispensary table
-        can :manage, Dispensary do |dispensary|
-          dispensary.admin_user == user
-        end
-        can :manage, DispensarySourceProduct do |dsp|
-          dsp.dispensary_source.dispensary.admin_user == user
-        end
-        can :manage, DspPrice do |dsp_price|
-          dsp_price.dispensary_source_product.dispensary_source.dispensary.admin_user == user
-        end
+        can :manage, Dispensary, {admin_user_id: user.id}
+        can :manage, DispensarySourceProduct, {dispensary_source: {dispensary: {admin_user_id: user.id}}}
+        can :manage, DspPrice, {dispensary_source_product: {dispensary_source: {dispensary: {admin_user_id: user.id}}}}
       end
     end
   end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,18 +1,17 @@
 class AdminUser < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, 
+  devise :database_authenticatable,
          :recoverable, :rememberable, :trackable, :validatable
-         
+
   #connect to dispensary
-  belongs_to :dispensary
   has_one :dispensary
   
   after_save :create_dispensary_source
   def create_dispensary_source
-    if self.role != 99 && self.dispensary_id.present?
+    if !is_admin? && self.dispensary_id.present?
       dsp_source = DispensarySource.where(dispensary_id: self.dispensary_id).
-                    order('last_menu_update DESC').first
+                    order(last_menu_update: :desc).first
       source = Source.where(name: 'Self').where(source_type: 'Dispensary').first
       cloned_dsp_source = dsp_source.clone
       cloned_dsp_source.dispensary_id = self.dispensary_id
@@ -22,5 +21,9 @@ class AdminUser < ActiveRecord::Base
         puts "Dispensary Source Error: #{cloned_dsp_source.errors.messages}"
       end
     end
+  end
+
+  def is_admin?
+    role == 99
   end
 end

--- a/app/models/dispensary.rb
+++ b/app/models/dispensary.rb
@@ -6,7 +6,6 @@ class Dispensary < ActiveRecord::Base
     validates :name, presence: true, length: {minimum: 1, maximum: 300}
     
     #admin
-    has_one :admin_user
     belongs_to :admin_user
     # scope :mine, -> { 
     #     AdminUser.where(:id => @current_admin_user.id).dispensaries.first


### PR DESCRIPTION
Because Ability class conditions are only invoked with certain method, we need to scope the dispensaries collection directly in ActiveAdmin controller.

The conditions in Ability class is also changed for easier integration with ActiveAdmin

I did not change much of the code but this should be good enough as a guideline.